### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ dist: bionic
 
 language: generic
 
+services:
+  - mysql
+
 script:
   - touch databases.yaml
   - ./setup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: generic
+
+script:
+  - touch databases.yaml
+  - ./setup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: bionic
+
 language: generic
 
 script:

--- a/install.sh
+++ b/install.sh
@@ -28,8 +28,8 @@ for service in $services; do
 
   # patch configuration (if patches exist)
   if [ -e "files/configuration/patches/$service.patch" ]; then
-    sudo patch --dry-run -d / -p0 -ruN < "files/configuration/patches/$service.patch"
-    sudo patch           -d / -p0 -ruN < "files/configuration/patches/$service.patch"
+    sudo patch --batch --dry-run -d / -p0 -ruN < "files/configuration/patches/$service.patch"
+    sudo patch --batch           -d / -p0 -ruN < "files/configuration/patches/$service.patch"
   fi
 
   # perform additional configuration (if it exists)


### PR DESCRIPTION
This change enables continuous integration (CI) testing using Travis
CI. Testing is currently limited to the execution of `setup.sh` to
install and configure all the services -- i.e., if this script
executes without failure, then the tests pass.

Further testing could be performed following the installation of
services. For example, after installing Apache and PHP, a web page
could be accessed to verify that the web page is rendered correctly.

Travis CI: https://travis-ci.com/