### PR TITLE
Grant PostgreSQL users ability to create databases

### DIFF
--- a/files/configuration/postgresql.sh
+++ b/files/configuration/postgresql.sh
@@ -84,7 +84,7 @@ while read -r line; do
 
   sudo -H -u postgres psql <<-SQL
 	-- create user
-	CREATE USER $username WITH LOGIN PASSWORD '$password';
+	CREATE USER $username WITH CREATEDB LOGIN PASSWORD '$password';
 
 	-- create database owned by user
 	CREATE DATABASE $username WITH OWNER $username;


### PR DESCRIPTION
This change alters the permissions given to PostgreSQL users so that
each user account has permission to create a database. Such permission
is required to isolate the databases used for different assignments.