### PR TITLE
Add message when setup.sh complete

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -30,3 +30,6 @@ db/restore.sh "$OLDPWD/databases.yaml"
 if ! [ -d ~/public_html ]; then
   mkdir ~/public_html
 fi
+
+echo
+echo "Setup completed successfully!"

--- a/setup.sh
+++ b/setup.sh
@@ -31,5 +31,10 @@ if ! [ -d ~/public_html ]; then
   mkdir ~/public_html
 fi
 
+
+# stop echoing commands to terminal
+set +x
+
+
 echo
 echo "Setup completed successfully!"


### PR DESCRIPTION
The slew of output when executing setup.sh isn't intuitive for anyone
who is unfamiliar with Dabian (or at least Linux). This change adds an
explicit success message to the end of the setup.sh so that it is
clear the script executed correctly.