### PR TITLE
Abort if database restoration fails

### DIFF
--- a/db/postgresql/load-database.sh
+++ b/db/postgresql/load-database.sh
@@ -21,4 +21,4 @@ set -x
 
 
 sudo -H -u postgres \
-    psql --dbname="$database" --echo-errors --quiet "$@"
+    psql --dbname="$database" --echo-errors --quiet --set=ON_ERROR_STOP=on "$@"


### PR DESCRIPTION
psql returns 0 to the shell even when errors occur in scripts unless
the variable ON_ERROR_STOP is set. Hence, this change sets that
variable so that any errors restoring a database cause the script to
exit with an error code.