### PR TITLE
Fail silently if curl encounters a server error

### DIFF
--- a/db/restore.sh
+++ b/db/restore.sh
@@ -26,7 +26,7 @@ while read -r line; do
 
   # download database dump
   filename="$(mktemp)"
-  curl --cookie-jar $(mktemp) --location --output "$filename" "$url"
+  curl --cookie-jar $(mktemp) --fail --location --output "$filename" "$url"
 
   # drop and (re)create database
   sudo -H -u postgres dropdb --if-exists "$database"


### PR DESCRIPTION
In most cases, HTTP servers return a document, even if that document
is a generic 404 error page. This change uses curl's `--fail` flag to
attempt to detect such cases and exit with an error condition.