### PR TITLE
Add CI workflow for setup script

### DIFF
--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -1,0 +1,30 @@
+name: Setup
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  setup:
+    runs-on: ubuntu-18.04
+    env:
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - uses: actions/checkout@v2
+      - name: install dependencies
+        run: |
+          sudo apt install --no-install-recommends --quiet --yes \
+              apt-utils \
+              patch \
+              sudo \
+              tzdata
+      - name: setup
+        env:
+          DB_PASSWORD: root
+        run: |
+          cat > "databases.yaml" <<- DATABASES
+            ISO3166: https://gist.githubusercontent.com/joel-coffman/be4e788a0d8d4bd5edbd4f525e2af544/raw/iso-3166.sql
+          DATABASES
+
+          ./setup.sh

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -26,6 +26,9 @@ jobs:
           cat > "databases.yaml" <<- DATABASES
             ISO3166: https://gist.githubusercontent.com/joel-coffman/be4e788a0d8d4bd5edbd4f525e2af544/raw/iso-3166.sql
           DATABASES
+          cat >> "db/users.yaml" <<- USERS
+            runner:
+          USERS
 
           ./setup.sh
       - name: verify database restore

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -28,8 +28,8 @@ jobs:
           DATABASES
 
           ./setup.sh
-      - name: verify database restore
-        run: |
+
+          # verify database(s) created by setup
           diff --unified \
               <(echo "   242"; echo) \
               <(psql --command="SELECT COUNT(*) FROM country;" \

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -32,5 +32,5 @@ jobs:
           # verify database(s) created by setup
           diff --unified \
               <(echo "   242"; echo) \
-              <(psql --command="SELECT COUNT(*) FROM country;" \
+              <(sudo psql --command="SELECT COUNT(*) FROM country;" \
                      --dbname="ISO3166" --tuples-only)

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -28,8 +28,8 @@ jobs:
           DATABASES
 
           ./setup.sh
-
-          # verify database(s) created by setup
+      - name: verify database restore
+        run: |
           diff --unified \
               <(echo "   242"; echo) \
               <(psql --command="SELECT COUNT(*) FROM country;" \

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -32,5 +32,5 @@ jobs:
           # verify database(s) created by setup
           diff --unified \
               <(echo "   242"; echo) \
-              <(sudo psql --command="SELECT COUNT(*) FROM country;" \
+              <(psql --command="SELECT COUNT(*) FROM country;" \
                      --dbname="ISO3166" --tuples-only)

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -28,3 +28,9 @@ jobs:
           DATABASES
 
           ./setup.sh
+      - name: verify database restore
+        run: |
+          diff --unified \
+              <(echo "   242"; echo) \
+              <(psql --command="SELECT COUNT(*) FROM country;" \
+                     --dbname="ISO3166" --tuples-only)


### PR DESCRIPTION
This change adds a continuous integration (CI) workflow to test the
setup script, specifically including the restoration of a PostgreSQL
database.