### PR TITLE
Enable PHP error reporting in user web directory

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -31,6 +31,12 @@ if ! [ -d ~/public_html ]; then
   mkdir ~/public_html
 fi
 
+# enable PHP error reporting
+cat - > ~/public_html/.htaccess <<- .htaccess
+php_flag display_errors on
+php_flag html_errors on
+.htaccess
+
 
 # stop echoing commands to terminal
 set +x


### PR DESCRIPTION
For someone learning PHP, enabling error reporting is essential, but
given the security risk of displaying errors, it's most sensible to
enable it locally -- i.e., using Apache's .htaccess files to enable
the configuration change for the user's web directory instead of
system-wide.

Closes #4