### PR TITLE
Update VM to use Ubuntu 22.04 as base

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   install:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   setup:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:

--- a/files/configuration/00-pgadmin4.sh
+++ b/files/configuration/00-pgadmin4.sh
@@ -15,7 +15,7 @@ set -x
 
 # install the public key for the repository
 curl -fsS https://www.pgadmin.org/static/packages_pgadmin_org.pub \
-    | sudo gpg --dearmor -o /usr/share/keyrings/packages-pgadmin-org.gpg
+    | sudo gpg --dearmor -o /usr/share/keyrings/packages-pgadmin-org.gpg --yes
 
 # create apt configuration file
 sudo sh -c \

--- a/files/configuration/00-pgadmin4.sh
+++ b/files/configuration/00-pgadmin4.sh
@@ -22,6 +22,3 @@ sudo sh -c \
 'echo "deb [signed-by=/usr/share/keyrings/packages-pgadmin-org.gpg] \
      https://ftp.postgresql.org/pub/pgadmin/pgadmin4/apt/$(lsb_release -cs) \
      pgadmin4 main" > /etc/apt/sources.list.d/pgadmin4.list && apt update'
-
-# install pgAdmin 4
-sudo apt install --quiet --yes pgadmin4-desktop

--- a/files/configuration/patches/apache2.patch
+++ b/files/configuration/patches/apache2.patch
@@ -1,6 +1,6 @@
-diff -u -r php7.2.conf php7.2.conf
---- /etc/apache2/mods-available/php7.2.conf	2020-01-21 15:37:04.749186590 -0800
-+++ /etc/apache2/mods-available/php7.2.conf	2020-01-21 15:40:25.181194660 -0800
+diff -u php8.1.conf.orig php8.1.conf
+--- /etc/apache2/mods-available/php8.1.conf	2023-07-19 11:34:30.478398010 -0600
++++ /etc/apache2/mods-available/php8.1.conf	2023-07-19 11:34:52.224008006 -0600
 @@ -12,14 +12,3 @@
  <FilesMatch "^\.ph(ar|p|ps|tml)$">
      Require all denied
@@ -16,9 +16,9 @@ diff -u -r php7.2.conf php7.2.conf
 -        php_admin_flag engine Off
 -    </Directory>
 -</IfModule>
-diff -u -r userdir.conf userdir.conf
---- /etc/apache2/mods-available/userdir.conf	2020-03-18 19:38:22.270154775 -0600
-+++ /etc/apache2/mods-available/userdir.conf	2020-03-18 19:38:13.762410778 -0600
+diff -u userdir.conf.orig userdir.conf
+--- /etc/apache2/mods-available/userdir.conf	2023-07-19 11:35:12.148053001 -0600
++++ /etc/apache2/mods-available/userdir.conf	2023-07-19 11:35:30.370053010 -0600
 @@ -3,7 +3,7 @@
  	UserDir disabled root
 

--- a/files/configuration/patches/postgresql.patch
+++ b/files/configuration/patches/postgresql.patch
@@ -1,18 +1,18 @@
-diff -u -r 10/main/pg_hba.conf 10/main/pg_hba.conf
---- /etc/postgresql/10/main/pg_hba.conf	2020-01-14 23:39:24.317740024 +0000
-+++ /etc/postgresql/10/main/pg_hba.conf	2020-01-14 23:23:46.956158422 +0000
-@@ -90,6 +90,7 @@
+diff -u pg_hba.conf.orig pg_hba.conf
+--- /etc/postgresql/14/main/pg_hba.conf	2023-07-19 11:23:50.573647006 -0600
++++ /etc/postgresql/14/main/pg_hba.conf	2023-07-19 11:24:35.077434012 -0600
+@@ -95,6 +95,7 @@
  local   all             all                                     peer
  # IPv4 local connections:
- host    all             all             127.0.0.1/32            md5
-+host    all             all             0.0.0.0/0               md5
+ host    all             all             127.0.0.1/32            scram-sha-256
++host    all             all             0.0.0.0/32              scram-sha-256
  # IPv6 local connections:
- host    all             all             ::1/128                 md5
+ host    all             all             ::1/128                 scram-sha-256
  # Allow replication connections from localhost, by a user with the
-diff -u -r 10/main/postgresql.conf 10/main/postgresql.conf
---- /etc/postgresql/10/main/postgresql.conf	2020-01-14 23:39:24.337740231 +0000
-+++ /etc/postgresql/10/main/postgresql.conf	2020-01-14 21:36:19.004224092 +0000
-@@ -56,7 +56,7 @@
+diff -u postgresql.conf.orig postgresql.conf
+--- /etc/postgresql/14/main/postgresql.conf	2023-07-19 11:23:55.970647008 -0600
++++ /etc/postgresql/14/main/postgresql.conf	2023-07-19 11:25:44.547544003 -0600
+@@ -57,7 +57,7 @@
  
  # - Connection Settings -
  

--- a/files/configuration/pgadmin4.sh
+++ b/files/configuration/pgadmin4.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+set -u
+
+
+# echo commands to terminal
+set -x
+
+
+#
+# pgAdmin 4 documentation: https://www.pgadmin.org/download/pgadmin-4-apt/
+#
+
+# install the public key for the repository
+curl -fsS https://www.pgadmin.org/static/packages_pgadmin_org.pub \
+    | sudo gpg --dearmor -o /usr/share/keyrings/packages-pgadmin-org.gpg
+
+# create apt configuration file
+sudo sh -c \
+'echo "deb [signed-by=/usr/share/keyrings/packages-pgadmin-org.gpg] \
+     https://ftp.postgresql.org/pub/pgadmin/pgadmin4/apt/$(lsb_release -cs) \
+     pgadmin4 main" > /etc/apt/sources.list.d/pgadmin4.list && apt update'
+
+# install pgAdmin 4
+sudo apt install pgadmin4-desktop

--- a/files/configuration/pgadmin4.sh
+++ b/files/configuration/pgadmin4.sh
@@ -24,4 +24,4 @@ sudo sh -c \
      pgadmin4 main" > /etc/apt/sources.list.d/pgadmin4.list && apt update'
 
 # install pgAdmin 4
-sudo apt install pgadmin4-desktop
+sudo apt install --quiet --yes pgadmin4-desktop

--- a/files/packages/00-pgadmin4
+++ b/files/packages/00-pgadmin4
@@ -1,0 +1,2 @@
+curl
+gpg

--- a/files/packages/apache2
+++ b/files/packages/apache2
@@ -1,3 +1,3 @@
 apache2
-libapache2-mod-php7.2
-php7.2
+libapache2-mod-php8.1
+php8.1

--- a/files/packages/mysql
+++ b/files/packages/mysql
@@ -1,2 +1,2 @@
 mysql-server
-php7.2-mysql
+php8.1-mysql

--- a/files/packages/pgadmin4
+++ b/files/packages/pgadmin4
@@ -1,0 +1,3 @@
+curl
+gpg
+lsb-release

--- a/files/packages/pgadmin4
+++ b/files/packages/pgadmin4
@@ -1,3 +1,1 @@
-curl
-gpg
-lsb-release
+pgadmin4-desktop

--- a/files/packages/postgresql
+++ b/files/packages/postgresql
@@ -1,4 +1,3 @@
-pgadmin3
 postgresql
 postgresql-client-common
 postgresql-contrib

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,7 @@ set -u
 
 os="$(lsb_release --id --short) $(lsb_release --release --short)"
 echo "Checking operating system... ${os}"
-if [ "${os}" != "Ubuntu 20.04" ]; then
+if [ "${os}" != "Ubuntu 22.04" ]; then
   {
     echo "$(lsb_release --description --short) is not supported"
   } >&2  # echo to stderr


### PR DESCRIPTION
Ubuntu 18.04 is no longer maintained (although it is scheduled to receive security updates through 2028-04-26). Consequently, this change transitions the virtual machine (VM) to use the latest long-term support (LTS) release, Ubuntu 22.04.