### PR TITLE
Abort if using the wrong Linux distribution

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -5,13 +5,31 @@ set -o pipefail
 set -u
 
 
-if ! [ -e "databases.yaml" ]; then
+os="$(lsb_release --id --short) $(lsb_release --release --short)"
+echo "Checking operating system... ${os}"
+if [ "${os}" != "Ubuntu 22.04" ]; then
   {
-    echo -n "Please download the database configuration (databases.yaml) "
+    echo "$(lsb_release --description --short) is not supported"
+  } >&2  # echo to stderr
+  exit 1
+fi
+
+echo -n "Checking for database configuration... "
+if [ -e "databases.yaml" ]; then
+  echo "found"
+else
+  echo "missing"
+  {
+    echo
+    echo -n "Download the database configuration (databases.yaml) "
     echo    "and place it in the current directory ($PWD)"
   } >&2  # echo to stderr
   exit 1
 fi
+
+echo
+echo "Starting setup..."
+echo
 
 
 # echo commands to terminal

--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,7 @@ set -u
 
 os="$(lsb_release --id --short) $(lsb_release --release --short)"
 echo "Checking operating system... ${os}"
-if [ "${os}" != "Ubuntu 22.04" ]; then
+if [ "${os}" != "Ubuntu 20.04" ]; then
   {
     echo "$(lsb_release --description --short) is not supported"
   } >&2  # echo to stderr


### PR DESCRIPTION
A non-trivial number of students install the latest version of Ubuntu instead of the specified release. This change explicitly checks the Linux distribution and aborts the setup if the wrong version is found.

Closes #22