### PR TITLE
Update GitHub Actions runner to Ubuntu 20.04

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -20,6 +20,10 @@ jobs:
               patch \
               sudo \
               tzdata
+      - name: remove incompatible packages
+        run: |
+          sudo apt remove --quiet --yes \
+              php7.4-common
       - name: install
         env:
           DB_PASSWORD: root

--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   install:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -19,6 +19,10 @@ jobs:
               patch \
               sudo \
               tzdata
+      - name: remove incompatible packages
+        run: |
+          sudo apt remove --quiet --yes \
+              php7.4-common
       - name: setup
         env:
           DB_PASSWORD: root

--- a/.github/workflows/setup.yaml
+++ b/.github/workflows/setup.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   setup:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       DEBIAN_FRONTEND: noninteractive
     steps:

--- a/files/configuration/patches/apache2.patch
+++ b/files/configuration/patches/apache2.patch
@@ -1,6 +1,6 @@
-diff -u -r php7.2.conf php7.2.conf
---- /etc/apache2/mods-available/php7.2.conf	2020-01-21 15:37:04.749186590 -0800
-+++ /etc/apache2/mods-available/php7.2.conf	2020-01-21 15:40:25.181194660 -0800
+diff -u -r php7.4.conf php7.4.conf
+--- /etc/apache2/mods-available/php7.4.conf	2020-01-21 15:37:04.749186590 -0800
++++ /etc/apache2/mods-available/php7.4.conf	2020-01-21 15:40:25.181194660 -0800
 @@ -12,14 +12,3 @@
  <FilesMatch "^\.ph(ar|p|ps|tml)$">
      Require all denied

--- a/files/packages/apache2
+++ b/files/packages/apache2
@@ -1,3 +1,3 @@
 apache2
-libapache2-mod-php7.2
-php7.2
+libapache2-mod-php
+php

--- a/files/packages/apache2
+++ b/files/packages/apache2
@@ -1,3 +1,3 @@
 apache2
-libapache2-mod-php
-php
+libapache2-mod-php7.4
+php7.4

--- a/files/packages/mysql
+++ b/files/packages/mysql
@@ -1,2 +1,2 @@
 mysql-server
-php7.2-mysql
+php-mysql

--- a/files/packages/mysql
+++ b/files/packages/mysql
@@ -1,2 +1,2 @@
 mysql-server
-php-mysql
+php7.4-mysql


### PR DESCRIPTION
Ubuntu 18.04 has been deprecated since 8 August 2022 and is no longer supported as of 3 April 2023. This change updates the GitHub Actions workflows to use the Ubuntu 20.04 runner instead.

References actions/runner-images#6002