### PR TITLE
Spell out "United States" in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,9 +4,9 @@ VM Configuration
 
 This repository contains scripts to automate the configuration of a virtual
 machine (VM) with all software required for Comp Sci 364: Databases and
-Applications at the `US Air Force Academy`_.
+Applications at the `United States Air Force Academy`_.
 
-.. _US Air Force Academy: https://www.usafa.edu/
+.. _United States Air Force Academy: https://www.usafa.edu/
 
 Usage
 =====


### PR DESCRIPTION
According to the brand guidelines, the "United States Air Force Academy" is preferred to "U.S. Air Force Academy."

Brand and Style Guide: https://www.usafa.edu/brand/